### PR TITLE
feat(api): listFiles/listFolders accept fields param

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,13 +251,15 @@ var NodeGoogleDrive = function(options) {
  *                                   explicitly set
  * @param  {boolean}  includeRemoved  Either to include removed files in the
  *                                   listing. Defaults to false
+ * @param  {string}  fields          - the partial fields that should be selected 
  * @return {Array<google.drive.files#resource>}   array of file resources results
  */
 NodeGoogleDrive.prototype.listFiles = function(
   parentFolder,
   pageToken,
   recursive,
-  includeRemoved
+  includeRemoved,
+  fields
 ) {
   var _this = this;
   var folderId = parentFolder || _this.options.ROOT_FOLDER;
@@ -266,7 +268,7 @@ NodeGoogleDrive.prototype.listFiles = function(
     includeRemoved: !!includeRemoved,
     spaces: 'drive',
     pageSize: 100,
-    fields: 'nextPageToken, files(id, name, parents, mimeType, modifiedTime)'
+    fields: fields || 'nextPageToken, files(id, name, parents, mimeType, modifiedTime)'
   };
 
   // If pageToken is set, then request the next page of file list
@@ -404,13 +406,15 @@ NodeGoogleDrive.prototype.getFile = function(file, destinationFolder) {
  *                                   subfolders. Works only when parentFolder is
  *                                   explicitly set
  * @param {boolean} includeRemoved - either to list removed folders or not
+ * @param  {string}  fields          - the partial fields that should be selected 
  * @return {Array<google.drive.files#resource>}   array of folder resources results
  */
 NodeGoogleDrive.prototype.listFolders = function(
   parentFolder,
   pageToken,
   recursive,
-  includeRemoved
+  includeRemoved,
+  fields
 ) {
   var _this = this;
   var folderId = parentFolder || _this.options.ROOT_FOLDER;
@@ -419,7 +423,7 @@ NodeGoogleDrive.prototype.listFolders = function(
     includeRemoved: !!includeRemoved,
     spaces: 'drive',
     pageSize: 100,
-    fields: 'nextPageToken, files(id, name, parents, mimeType, modifiedTime)'
+    fields: fields || 'nextPageToken, files(id, name, parents, mimeType, modifiedTime)'
   };
 
   // If pageToken is set, then request the next page of file list


### PR DESCRIPTION
This allows the consumer to pass in the fields of interest to be used when partially requesting files or folders. Currently the value is hard-coded