### PR TITLE
Converting upload files to google docs if provided

### DIFF
--- a/API.md
+++ b/API.md
@@ -133,6 +133,7 @@ ___
 -   `parentFolder` **[string][4]?** The parent folder on which to write. Defaults to the ROOT_FOLDER passed in the constructor options
 -   `destinationFilename` **[string][4]?** The destination filename, defaults to the basename of the uploaded file
 -   `mimeType` **[string][4]?** The file's mime type. If not provided, we will try to detect it, which won't work for non binary types
+-   `destinationMimeType` **[string][4]?** The file's destination mime type. This will help in conversion for files that can be processed by google drive. **Eg.** "application/vnd.google-apps.spreadsheet" for "text/csv" mimetype to convert into google sheet
 
 Returns **[Promise][8]&lt;[Object][1]>** the response from google drive
 ___

--- a/index.js
+++ b/index.js
@@ -583,7 +583,8 @@ NodeGoogleDrive.prototype.writeFile = function(
   sourcefile,
   parentFolder,
   destinationFilename,
-  mimeType
+  mimeType,
+  destinationMimeType,
 ) {
   var _this = this;
   var defaultsource = path.resolve(__dirname + '/data/sample.pdf');
@@ -591,12 +592,13 @@ NodeGoogleDrive.prototype.writeFile = function(
   var folderId = parentFolder || _this.options.ROOT_FOLDER;
 
   var file_path = sourcefile || defaultsource;
+  var destinationType = destinationMimeType || mimeType;
 
   return readChunk(file_path, 0, 4100)
     .then(buffer => {
       var fileMetadata = {
         name: destinationFilename || path.basename(file_path),
-        mimeType: mimeType || fileType(buffer).mime
+        mimeType: destinationType || fileType(buffer).mime
       };
       if (folderId !== null) {
         fileMetadata.parents = [folderId];

--- a/index.js
+++ b/index.js
@@ -584,7 +584,7 @@ NodeGoogleDrive.prototype.writeFile = function(
   parentFolder,
   destinationFilename,
   mimeType,
-  destinationMimeType,
+  opts = {},
 ) {
   var _this = this;
   var defaultsource = path.resolve(__dirname + '/data/sample.pdf');
@@ -592,7 +592,8 @@ NodeGoogleDrive.prototype.writeFile = function(
   var folderId = parentFolder || _this.options.ROOT_FOLDER;
 
   var file_path = sourcefile || defaultsource;
-  var destinationType = destinationMimeType || mimeType;
+  var destinationType = opts.destinationMimeType || mimeType;
+  var fields = opts.fields || 'id, name, parents, mimeType, modifiedTime';
 
   return readChunk(file_path, 0, 4100)
     .then(buffer => {
@@ -609,7 +610,8 @@ NodeGoogleDrive.prototype.writeFile = function(
         media: {
           mimeType: mimeType,
           body: fs.createReadStream(file_path)
-        }
+        },
+        fields: fields,
       });
     })
     .then(function(response) {


### PR DESCRIPTION
We can convert files from their normal format to google docs format using drive provided API's. I have exposed one more parameter in the writeFile function to help convert uploading file to google doc format.